### PR TITLE
Add undeploy.json

### DIFF
--- a/db/undeploy.json
+++ b/db/undeploy.json
@@ -1,0 +1,7 @@
+[
+  "src/gen/**/*.hdbview",
+  "src/gen/**/*.hdbindex",
+  "src/gen/**/*.hdbconstraint",
+  "src/gen/**/*_drafts.hdbtable",
+  "src/gen/**/*.hdbcalculationview"
+]


### PR DESCRIPTION
This is the standard `undeploy.json` created by `cds add hana`.

In CDS 10 we could also let `cds build` generate it if it doesn't exist. 

This file missing is the reason we currently get deployment issues in https://github.com/capire/samples/actions/runs/16732123973/job/47413558425, after the data model was changed.

With that commit checked out it is fixed:
https://github.com/capire/samples/pull/18