### PR TITLE
Also undeploy `hdbtabledata` files

### DIFF
--- a/db/undeploy.json
+++ b/db/undeploy.json
@@ -3,5 +3,6 @@
   "src/gen/**/*.hdbindex",
   "src/gen/**/*.hdbconstraint",
   "src/gen/**/*_drafts.hdbtable",
-  "src/gen/**/*.hdbcalculationview"
+  "src/gen/**/*.hdbcalculationview",
+  "src/gen/**/*.hdbtabledata"
 ]


### PR DESCRIPTION
In our microservices sample we are using initial CSV data and run into exactly these caveats:
https://cap.cloud.sap/docs/guides/databases-hana#caveats

I think for now it's fine to undeploy all `.hdbtabledata` as well, as it's meant to be just sample data.